### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   laravel-tests:
 


### PR DESCRIPTION
Potential fix for [https://github.com/GentilOfficial/Task-Manager/security/code-scanning/1](https://github.com/GentilOfficial/Task-Manager/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily interacts with the repository's contents (e.g., checking out code) and does not appear to require write access. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
