### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/resources/js/pages/ErrorPage.vue
+++ b/resources/js/pages/ErrorPage.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { Button } from '@/components/ui/button';
 import AuthBase from '@/layouts/AuthLayout.vue';
 import { Head, Link } from '@inertiajs/vue3';


### PR DESCRIPTION
Potential fix for [https://github.com/GentilOfficial/Task-Manager/security/code-scanning/3](https://github.com/GentilOfficial/Task-Manager/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `ci` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
